### PR TITLE
refactor: Update GitHub Pages deployment to use gh-pages branch

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,4 +1,4 @@
-name: Deploy Frontend to GitHub Pages
+name: Deploy Frontend to gh-pages
 
 on:
   push:
@@ -9,54 +9,39 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push to gh-pages branch
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up Node.js (if you were using a build step, e.g., for Tailwind JIT or minification)
-        # uses: actions/setup-node@v3
-        # with:
-        #   node-version: '18' # Or your preferred version
-        #   cache: 'npm' # Or 'yarn'
-        #   cache-dependency-path: frontend/package-lock.json # Or equivalent
+      # Optional: If you had a build step (e.g., for Tailwind JIT, SASS, minification)
+      # - name: Set up Node.js
+      #   uses: actions/setup-node@v3
+      #   with:
+      #     node-version: '18'
+      #     cache: 'npm'
+      #     cache-dependency-path: frontend/package-lock.json # if you have one
 
       # - name: Install frontend dependencies (if any)
-      #   if: steps.setup-node.conclusion == 'success' # Only run if Node setup was intended
       #   working-directory: ./frontend
-      #   run: npm ci # Or yarn install
+      #   run: npm ci # if you have a package-lock.json
 
       # - name: Build frontend (if any)
-      #   if: steps.setup-node.conclusion == 'success'
       #   working-directory: ./frontend
-      #   run: npm run build # Or your build command
+      #   run: npm run build # if you have a build script
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+      - name: Deploy to GitHub Pages (gh-pages branch)
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          # Upload the frontend directory
-          path: './frontend'
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./frontend
+          # publish_branch: gh-pages # This is the default, so it's optional to specify
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'Deploy frontend to gh-pages'
+          # force_orphan: true # Use this if you want to ensure a clean history on gh-pages

--- a/README.md
+++ b/README.md
@@ -25,7 +25,16 @@ The project is automatically built and deployed using GitHub Actions, with the f
 
 ## 🚀 Live Demo (GitHub Pages)
 
-You should be able to access the live application at: `https://<your-github-username>.github.io/pdf-converter-app/` (Replace `<your-github-username>` with your actual GitHub username after the first deployment).
+To enable the live demo:
+
+1.  After the first successful run of the "Deploy Frontend to gh-pages" workflow (see Actions tab), a `gh-pages` branch will be created in your repository.
+2.  Go to your GitHub repository's **Settings** page.
+3.  In the left sidebar, click on **Pages**.
+4.  Under "Build and deployment", for the **Source**, select **Deploy from a branch**.
+5.  Under "Branch", select `gh-pages` as the branch and `/ (root)` as the folder.
+6.  Click **Save**.
+
+Your application will then be available at: `https://<your-github-username>.github.io/pdf-converter-app/` (Replace `<your-github-username>` with your actual GitHub username). It might take a few minutes for the site to become active after saving.
 
 ## 🛠️ Technologies Used
 
@@ -103,13 +112,16 @@ To run the backend unit tests:
 ## 🔄 GitHub Actions & Deployments
 
 *   **Backend CI**: Pushes or pull requests to the `main` branch affecting the `backend/` directory or `.github/workflows/backend.yml` will trigger the backend CI workflow. This workflow installs dependencies (including `pandoc`) and runs unit tests.
-*   **Frontend Deployment**: Pushes to the `main` branch affecting the `frontend/` directory or `.github/workflows/frontend.yml` will trigger the frontend deployment workflow. This workflow deploys the contents of the `frontend/` directory to GitHub Pages.
+*   **Frontend Deployment**: Pushes to the `main` branch affecting the `frontend/` directory or `.github/workflows/frontend.yml` will trigger the "Deploy Frontend to gh-pages" workflow. This workflow:
+    1.  Checks out the `main` branch.
+    2.  Pushes the entire content of the `frontend/` directory to the `gh-pages` branch.
+    *   **Important**: You need to configure GitHub Pages in your repository settings to serve from the `gh-pages` branch (see "Live Demo" section above for instructions).
 
 You can view the status of these actions under the "Actions" tab of your GitHub repository.
 
 To manually trigger a frontend deployment (if `workflow_dispatch` is enabled in `frontend.yml`):
 1.  Go to the "Actions" tab in your GitHub repository.
-2.  Select the "Deploy Frontend to GitHub Pages" workflow from the list.
+2.  Select the "Deploy Frontend to gh-pages" workflow from the list.
 3.  Click on "Run workflow", choose the branch (usually `main`), and click "Run workflow".
 
 ## 📄 How to Test Conversions


### PR DESCRIPTION
This commit modifies the frontend deployment strategy:

- The `.github/workflows/frontend.yml` workflow now pushes the `frontend/` directory contents to the `gh-pages` branch using the `peaceiris/actions-gh-pages` action.
- The `README.md` has been updated to instruct you on how to configure your GitHub repository settings to serve GitHub Pages from the `gh-pages` branch.

This approach is a common practice for GitHub Pages deployment, providing a dedicated branch for the live site content.