### PR TITLE
fix: Enable CORS in backend and update docs for frontend-backend comm…

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ uvicorn main:app --reload --host 0.0.0.0 --port 8000
 ```
 The backend API will be available at `http://localhost:8000`. You can see the API docs at `http://localhost:8000/docs`.
 
+**Important Note on CORS:**
+The backend is configured with CORS (Cross-Origin Resource Sharing) to allow requests from typical frontend development servers (like `http://localhost:8080`, `http://127.0.0.1:8080`) and from all origins (`*`). This `"*"` setting is for ease of development and testing with services like GitHub Pages. For a production deployment of the backend, you should restrict the `origins` list in `backend/main.py` to only the specific domains where your frontend is hosted.
+
 ### 3. Frontend Setup
 
 1.  Navigate to the `frontend` directory:
@@ -108,6 +111,28 @@ To run the backend unit tests:
 
     python -m unittest discover -s ./tests -p "test_*.py"
     ```
+
+## 🔗 Connecting Frontend (GitHub Pages) to Backend
+
+The frontend application, whether run locally (`index.html`) or deployed via GitHub Pages, needs to connect to a running backend API.
+
+*   **Backend Location**: The Python backend (FastAPI server) must be running. This can be:
+    *   Locally on your machine (e.g., `python backend/main.py` or `uvicorn backend.main:app --reload --port 8000`).
+    *   Deployed to a hosting service (e.g., Heroku, AWS, Google Cloud).
+
+*   **Configuring the API URL in Frontend**:
+    The frontend needs to know the backend's URL. This is set in `frontend/script.js`:
+    ```javascript
+    const API_BASE_URL = 'http://localhost:8000';
+    ```
+    *   **For local development**: If your backend is running on `http://localhost:8000`, this default URL is correct.
+    *   **For GitHub Pages with a local backend**: If you are using the GitHub Pages frontend, you still need to run the backend locally. The GitHub Pages site will try to make requests to `http://localhost:8000` on *your computer*. Ensure your browser can access this (some browsers/extensions might block localhost access from `https://` sites, but generally this works for development).
+    *   **For GitHub Pages with a deployed backend**: If you have deployed your backend to a public URL (e.g., `https://your-backend-api.com`), you **must** update `API_BASE_URL` in `frontend/script.js` to this public URL, then commit and push this change so your GitHub Pages site uses the correct API endpoint.
+
+**If you see "NetworkError" or conversion button doesn't work on GitHub Pages:**
+1.  **Ensure your local Python backend is running.**
+2.  **Check the browser's developer console (usually F12) for error messages.** CORS errors or mixed content warnings might appear if the backend is not configured correctly or if the `API_BASE_URL` is wrong.
+3.  The backend's CORS policy is currently set to allow all origins (`*`) for easier testing. If you changed this, ensure your GitHub Pages URL (`https://<username>.github.io`) is in the allowed list.
 
 ## 🔄 GitHub Actions & Deployments
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,17 +1,47 @@
 from fastapi import FastAPI, File, UploadFile, HTTPException
+from fastapi.middleware.cors import CORSMiddleware # Import CORS middleware
 from fastapi.responses import FileResponse
 import shutil
 import os
-from converter import convert_pdf
-from utils import get_file_extension
+from converter import convert_pdf # Assuming converter.py is in the same directory or PYTHONPATH is set
+from utils import get_file_extension # Assuming utils.py is in the same directory
 
 app = FastAPI()
 
+# CORS Configuration
+origins = [
+    "http://localhost", # Local development (if frontend served by a local server on a different port)
+    "http://localhost:8080", # Common local dev port for frontend
+    "http://127.0.0.1",
+    "http://127.0.0.1:8080",
+    # Add the GitHub Pages URL pattern.
+    # This is a generic pattern. For a specific user/repo:
+    # "https://<USERNAME>.github.io",
+    # Using a wildcard for subdomains of github.io might be too broad.
+    # For now, let's add a placeholder and instruct user to specify.
+    # Or, allow all origins for simplicity if this is primarily a local tool or demo.
+    # For a public-facing backend, be more restrictive.
+    "*" # Allows all origins - USE WITH CAUTION FOR PRODUCTION
+    # A better approach for GitHub Pages would be:
+    # "https://your-username.github.io"
+    # If you know the username. Since I don't, I'll use '*' for now and add a note.
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins, # List of origins that are allowed to make requests
+    allow_credentials=True, # Allow cookies to be included in requests
+    allow_methods=["*"], # Allow all methods (GET, POST, etc.)
+    allow_headers=["*"], # Allow all headers
+)
+
 UPLOAD_DIR = "uploads"
-OUTPUT_DIR = "../output" # Adjusted path relative to backend directory
+# Output directory should be relative to the project root, not the backend directory.
+# Assuming main.py is in backend/, then ../output/ is correct for output/ at project root.
+OUTPUT_DIR = "../output"
 
 os.makedirs(UPLOAD_DIR, exist_ok=True)
-os.makedirs(OUTPUT_DIR, exist_ok=True)
+os.makedirs(OUTPUT_DIR, exist_ok=True) # Ensure this path is correct relative to where main.py runs
 
 @app.post("/upload/")
 async def upload_pdf(file: UploadFile = File(...)):
@@ -34,9 +64,12 @@ async def convert_pdf_endpoint(filename: str, output_format: str):
         raise HTTPException(status_code=404, detail="Uploaded file not found.")
 
     try:
+        # Ensure convert_pdf knows where to save files (OUTPUT_DIR)
         output_file_path = convert_pdf(uploaded_file_path, output_format, OUTPUT_DIR)
         return {"message": f"File converted successfully to {output_format}", "output_file": os.path.basename(output_file_path)}
     except Exception as e:
+        # Log the exception for debugging on the server
+        print(f"Conversion error: {e}")
         raise HTTPException(status_code=500, detail=f"Conversion failed: {str(e)}")
 
 @app.get("/download/{filename}")
@@ -49,4 +82,9 @@ async def download_file(filename: str):
 
 if __name__ == "__main__":
     import uvicorn
+    # Note: Uvicorn's --reload flag is great for dev but might not pick up all env changes for origins
+    # without a full restart if origins are dynamically configured.
+    # For this setup with a static list, it's fine.
+    print(f"Backend starting. UPLOAD_DIR: {os.path.abspath(UPLOAD_DIR)}, OUTPUT_DIR: {os.path.abspath(OUTPUT_DIR)}")
+    print(f"Allowed CORS origins: {origins}")
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -8,9 +8,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let selectedFile = null;
 
-    // Backend API URL (adjust if your backend runs elsewhere)
-    // Assuming backend is running on port 8000 locally for development
+    // --- Configuration ---
+    // IMPORTANT: Set this URL to where your backend API is running.
+    // For local development, this is typically http://localhost:8000.
+    // If you deploy the backend to a different server, update this URL.
     const API_BASE_URL = 'http://localhost:8000';
+    // --- End Configuration ---
 
     pdfFileElement.addEventListener('change', (event) => {
         selectedFile = event.target.files[0];


### PR DESCRIPTION
…unication

This commit addresses issues with the frontend (especially when deployed on GitHub Pages) communicating with the backend due to browser same-origin policy.

Changes include:
- Modified `backend/main.py` to include `CORSMiddleware`.
  - For development and initial testing, allowed origins is set to `*`. A note has been added about restricting this for production.
- Reviewed `frontend/script.js` and enhanced comments for the `API_BASE_URL` constant to clarify its role in connecting to the backend.
- Updated `README.md` significantly:
  - Added information about the backend's CORS setup.
  - Included a new section "Connecting Frontend (GitHub Pages) to Backend" that explains how to ensure the frontend can reach the backend, the importance of a running backend instance, and how to configure `API_BASE_URL` in `script.js`.
  - Added troubleshooting tips for common network errors.