### PR TITLE
fix: Resolve errors in PDF conversion logic and tests

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -28,13 +28,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install system dependencies (like Pandoc)
+    - name: Install system dependencies (Pandoc)
       run: |
         sudo apt-get update
-        sudo apt-get install -y pandoc libreoffice # For unoconv (if used, and if it implies full LO install)
-        # Note: unoconv might require more setup or a running LibreOffice instance,
-        # which can be tricky in CI. Pandoc is more straightforward.
-        # If unoconv is strictly needed and causes issues, consider Docker for a more controlled env.
+        sudo apt-get install -y pandoc
+        # Note: unoconv (requiring LibreOffice) was removed as it's not directly used by the core conversion logic.
+        # Pandoc is the primary system dependency for docx/odt.
 
     - name: Install Python dependencies
       working-directory: ./backend
@@ -46,7 +45,7 @@ jobs:
     - name: Run tests
       working-directory: ./backend
       run: |
-        # Ensure the backend directory itself is in PYTHONPATH for imports like 'from backend.converter import ...'
+        # Ensure the project root is in PYTHONPATH for imports like 'from backend.converter import ...'
         # This is often needed if tests are structured in a subdirectory and import from parent package.
         export PYTHONPATH=${{ github.workspace }}:$PYTHONPATH
         python -m unittest discover -s ./tests -p "test_*.py"

--- a/backend/tests/test_converter.py
+++ b/backend/tests/test_converter.py
@@ -44,21 +44,25 @@ class TestConverter(unittest.TestCase):
             os.remove(cls.TEST_PDF_PATH)
         if os.path.exists(os.path.join(cls.BASE_DIR, cls.TEST_OUTPUT_DIR)):
             shutil.rmtree(os.path.join(cls.BASE_DIR, cls.TEST_OUTPUT_DIR))
-        # Optionally clean the main output dir if it was only for tests
-        # For now, let's assume the main output dir might be used by other processes or manual checks
-        # if os.path.exists(cls.PROJECT_ROOT_OUTPUT_DIR):
-        #     shutil.rmtree(cls.PROJECT_ROOT_OUTPUT_DIR)
+        # Clean up files generated in the main output directory by this test class
+        for fmt in ["md", "txt", "docx", "odt", "xyz"]: # xyz for the unsupported format test if it ever creates a file
+            expected_output_file = os.path.join(cls.PROJECT_ROOT_OUTPUT_DIR, f"{os.path.splitext(cls.TEST_PDF_FILENAME)[0]}.{fmt}")
+            if os.path.exists(expected_output_file):
+                os.remove(expected_output_file)
 
 
     def test_convert_to_md(self):
         output_file = convert_pdf(self.TEST_PDF_PATH, "md", self.PROJECT_ROOT_OUTPUT_DIR)
         self.assertTrue(os.path.exists(output_file))
         self.assertTrue(output_file.endswith(".md"))
-        # Add more assertions here: check content, link preservation (if feasible in test)
         with open(output_file, "r", encoding="utf-8") as f:
             content = f.read()
         self.assertIn("Hello, this is a test PDF", content)
-        self.assertIn("[Link to Example](https://www.example.com)", content) # PyMuPDF md format
+        # Pandoc's HTML to MD conversion of PyMuPDF's XHTML output
+        # The exact link format might vary based on Pandoc version and input HTML.
+        # A robust check would be for the presence of "Link to Example" and "example.com".
+        self.assertIn("Link to Example", content, "Link text not found in Markdown")
+        self.assertIn("example.com", content, "Link URL not found in Markdown")
 
     def test_convert_to_txt(self):
         output_file = convert_pdf(self.TEST_PDF_PATH, "txt", self.PROJECT_ROOT_OUTPUT_DIR)


### PR DESCRIPTION
This commit addresses several issues in the PDF conversion process and the corresponding backend unit tests:

- **Markdown Conversion (`backend/converter.py`):**
  - Resolved `AttributeError: 'Document' object has no attribute 'get_text'` with certain flags for Markdown.
  - The conversion now extracts XHTML page by page using PyMuPDF's `page.get_text("xhtml")`.
  - This XHTML is then passed to Pandoc to convert from HTML to Markdown, improving reliability and link preservation.

- **DOCX/ODT Conversion (`backend/converter.py`):**
  - Aligned with the Markdown approach, DOCX/ODT conversion now also extracts XHTML page by page using `page.get_text("xhtml")`.
  - This XHTML is passed to Pandoc (from HTML input) to generate `.docx` and `.odt` files, which is more robust than direct PDF input to Pandoc for these formats.

- **Test Corrections (`backend/tests/test_converter.py`):**
  - Ensured `test_unsupported_format` correctly asserts for `ValueError` (it appeared to be correct already or fixed implicitly).
  - Updated `test_convert_to_md` to more robustly check for the presence of link text and URL components in the generated Markdown, accommodating Pandoc's output style.
  - Improved `tearDownClass` to be more specific in cleaning up test-generated files from the output directory.

- **General (`backend/converter.py`):**
  - Ensured `fitz.Document` objects are closed in all execution paths, including error handling, to prevent resource leaks.
  - Refined exception handling to re-raise `ValueError` specifically when it occurs, allowing tests to catch it accurately.